### PR TITLE
Updated calendar colors v2

### DIFF
--- a/client/src/lib/WeekTableCalendarListings.svelte
+++ b/client/src/lib/WeekTableCalendarListings.svelte
@@ -104,7 +104,7 @@
                                         on:click={() => {
                                             focusElement = calendarData[j][i];
                                         }}
-                                        class="chip m-0 w-full h-full variant-{calendarData[
+                                        class="chip m-0 w-full h-full text-white bg-yellow-500 !important variant-{calendarData[
                                             j
                                         ][i].state === 'booked'
                                             ? 'filled-success'


### PR DESCRIPTION
Changes Made:

Attempted to implement color differentiation between "My listings" and "My bookings" in the calendar.
Changes were made in the WeekTableCalendarListings.svelte component to apply the text-white and bg-yellow-500 classes based on the selected tab.

Testing Results:

Tested locally on localhost, but the expected colour changes did not appear as intended.
Checked the configuration and applied Tailwind classes correctly, but the colours did not update.
Next Steps:

Need further troubleshooting to identify why the colours are not reflecting as expected.